### PR TITLE
チーム・ペア・参加者の紐付け

### DIFF
--- a/backend/prisma/migrations/20230223055612_team_pair_participant/migration.sql
+++ b/backend/prisma/migrations/20230223055612_team_pair_participant/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "pairs" ADD COLUMN     "team_id" TEXT NOT NULL DEFAULT 'undefined';
+
+-- AlterTable
+ALTER TABLE "participants" ADD COLUMN     "team_id" TEXT NOT NULL DEFAULT 'undefined';
+
+-- AddForeignKey
+ALTER TABLE "pairs" ADD CONSTRAINT "pairs_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "participants" ADD CONSTRAINT "participants_team_id_fkey" FOREIGN KEY ("team_id") REFERENCES "teams"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20230223055832_re_team_pair_participant/migration.sql
+++ b/backend/prisma/migrations/20230223055832_re_team_pair_participant/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "pairs" ALTER COLUMN "team_id" SET DEFAULT '1';
+
+-- AlterTable
+ALTER TABLE "participants" ALTER COLUMN "team_id" SET DEFAULT '1';

--- a/backend/prisma/migrations/20230223060322_remove_default_value/migration.sql
+++ b/backend/prisma/migrations/20230223060322_remove_default_value/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "pairs" ALTER COLUMN "team_id" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "participants" ALTER COLUMN "team_id" DROP DEFAULT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,10 +8,12 @@ datasource db {
 }
 
 model Team {
-  id        String   @id @db.VarChar(255)
-  name      String   @db.VarChar(255)
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  id          String        @id @db.VarChar(255)
+  name        String        @db.VarChar(255)
+  createdAt   DateTime      @default(now()) @map("created_at")
+  updatedAt   DateTime      @updatedAt @map("updated_at")
+  pairs       Pair[]
+  Participant Participant[]
 
   @@map("teams")
 }
@@ -22,6 +24,8 @@ model Pair {
   createdAt    DateTime      @default(now()) @map("created_at")
   updatedAt    DateTime      @updatedAt @map("updated_at")
   participants Participant[]
+  teamId       String        @default("1") @map("team_id")
+  Team         Team          @relation(fields: [teamId], references: [id])
 
   @@map("pairs")
 }
@@ -33,6 +37,8 @@ model Participant {
   status    Int
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+  teamId    String   @default("1") @map("team_id")
+  Team      Team     @relation(fields: [teamId], references: [id])
   pairId    String   @map("pair_id")
   Pair      Pair     @relation(fields: [pairId], references: [id])
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -24,7 +24,7 @@ model Pair {
   createdAt    DateTime      @default(now()) @map("created_at")
   updatedAt    DateTime      @updatedAt @map("updated_at")
   participants Participant[]
-  teamId       String        @default("1") @map("team_id")
+  teamId       String        @map("team_id")
   Team         Team          @relation(fields: [teamId], references: [id])
 
   @@map("pairs")
@@ -37,7 +37,7 @@ model Participant {
   status    Int
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
-  teamId    String   @default("1") @map("team_id")
+  teamId    String   @map("team_id")
   Team      Team     @relation(fields: [teamId], references: [id])
   pairId    String   @map("pair_id")
   Pair      Pair     @relation(fields: [pairId], references: [id])

--- a/backend/src/domain/repository-interface/pair-repository.ts
+++ b/backend/src/domain/repository-interface/pair-repository.ts
@@ -6,6 +6,7 @@ export class PairDto {
   public readonly participants: ParticipantDto[];
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
+  public readonly teamId: string;
 
   constructor(props: {
     id: string;
@@ -13,13 +14,15 @@ export class PairDto {
     participants: ParticipantDto[];
     createdAt: Date;
     updatedAt: Date;
+    teamId: string;
   }) {
-    const { id, name, participants, createdAt, updatedAt } = props;
+    const { id, name, participants, createdAt, updatedAt, teamId } = props;
     this.id = id;
     this.name = name;
     this.participants = participants;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.teamId = teamId;
   }
 }
 

--- a/backend/src/domain/repository-interface/participant-repository.ts
+++ b/backend/src/domain/repository-interface/participant-repository.ts
@@ -5,6 +5,7 @@ export class ParticipantDto {
   public readonly status: number;
   public readonly createdAt: Date;
   public readonly updatedAt: Date;
+  public readonly teamId: string;
   public readonly pairId: string;
 
   constructor(props: {
@@ -14,15 +15,18 @@ export class ParticipantDto {
     status: number;
     createdAt: Date;
     updatedAt: Date;
+    teamId: string;
     pairId: string;
   }) {
-    const { id, name, email, status, createdAt, updatedAt, pairId } = props;
+    const { id, name, email, status, createdAt, updatedAt, teamId, pairId } =
+      props;
     this.id = id;
     this.name = name;
     this.email = email;
     this.status = status;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.teamId = teamId;
     this.pairId = pairId;
   }
 }

--- a/backend/src/infra/db/repository/pair/pair-repository.integration.spec.ts
+++ b/backend/src/infra/db/repository/pair/pair-repository.integration.spec.ts
@@ -5,17 +5,35 @@ import { PairDto } from '../../../../domain/repository-interface/pair-repository
 describe('PairRepository', () => {
   const pairRepository = new PairRepository(prisma);
 
-  beforeEach(async () => {
+  afterEach(async () => {
     // https://www.prisma.io/docs/concepts/components/prisma-client/crud#cascading-deletes-deleting-related-records
     const deleteParticipants = prisma.participant.deleteMany({});
     const deletePairs = prisma.pair.deleteMany({});
+    const deleteTeams = prisma.team.deleteMany({});
 
-    await prisma.$transaction([deleteParticipants, deletePairs]);
+    await prisma.$transaction([deleteParticipants, deletePairs, deleteTeams]);
   });
 
   describe('findAll', () => {
     it('正常系 全てのペアを取得できること', async () => {
       // Arrange
+      await prisma.team.createMany({
+        data: [
+          {
+            id: '1',
+            name: '001',
+            createdAt: '2023-01-01T09:00:00Z',
+            updatedAt: '2023-01-01T09:00:00Z',
+          },
+          {
+            id: '2',
+            name: '002',
+            createdAt: '2023-02-01T09:00:00Z',
+            updatedAt: '2023-02-01T09:00:00Z',
+          },
+        ],
+      });
+
       await prisma.pair.create({
         include: {
           participants: true,
@@ -32,6 +50,7 @@ describe('PairRepository', () => {
                 status: 1,
                 createdAt: '2023-01-01T09:00:00Z',
                 updatedAt: '2023-01-01T09:00:00Z',
+                teamId: '1',
               },
               {
                 id: '2',
@@ -40,11 +59,13 @@ describe('PairRepository', () => {
                 status: 2,
                 createdAt: '2023-01-01T09:00:00Z',
                 updatedAt: '2023-01-01T09:00:00Z',
+                teamId: '1',
               },
             ],
           },
           createdAt: '2023-01-01T09:00:00Z',
           updatedAt: '2023-01-01T09:00:00Z',
+          teamId: '1',
         },
       });
 
@@ -64,6 +85,7 @@ describe('PairRepository', () => {
                 status: 1,
                 createdAt: '2023-01-01T09:00:00Z',
                 updatedAt: '2023-01-01T09:00:00Z',
+                teamId: '2',
               },
               {
                 id: '4',
@@ -72,11 +94,13 @@ describe('PairRepository', () => {
                 status: 2,
                 createdAt: '2023-01-01T09:00:00Z',
                 updatedAt: '2023-01-01T09:00:00Z',
+                teamId: '2',
               },
             ],
           },
           createdAt: '2023-01-01T09:00:00Z',
           updatedAt: '2023-01-01T09:00:00Z',
+          teamId: '2',
         },
       });
 
@@ -96,6 +120,7 @@ describe('PairRepository', () => {
               status: 1,
               createdAt: new Date('2023-01-01T09:00:00Z'),
               updatedAt: new Date('2023-01-01T09:00:00Z'),
+              teamId: '1',
               pairId: '1',
             },
             {
@@ -105,11 +130,13 @@ describe('PairRepository', () => {
               status: 2,
               createdAt: new Date('2023-01-01T09:00:00Z'),
               updatedAt: new Date('2023-01-01T09:00:00Z'),
+              teamId: '1',
               pairId: '1',
             },
           ],
           createdAt: new Date('2023-01-01T09:00:00Z'),
           updatedAt: new Date('2023-01-01T09:00:00Z'),
+          teamId: '1',
         }),
         new PairDto({
           id: '2',
@@ -122,6 +149,7 @@ describe('PairRepository', () => {
               status: 1,
               createdAt: new Date('2023-01-01T09:00:00Z'),
               updatedAt: new Date('2023-01-01T09:00:00Z'),
+              teamId: '2',
               pairId: '2',
             },
             {
@@ -131,11 +159,13 @@ describe('PairRepository', () => {
               status: 2,
               createdAt: new Date('2023-01-01T09:00:00Z'),
               updatedAt: new Date('2023-01-01T09:00:00Z'),
+              teamId: '2',
               pairId: '2',
             },
           ],
           createdAt: new Date('2023-01-01T09:00:00Z'),
           updatedAt: new Date('2023-01-01T09:00:00Z'),
+          teamId: '2',
         }),
       ]);
     });

--- a/backend/src/infra/db/repository/pair/pair-repository.ts
+++ b/backend/src/infra/db/repository/pair/pair-repository.ts
@@ -22,6 +22,7 @@ export class PairRepository implements IPairRepository {
           participants: pair.participants,
           createdAt: pair.createdAt,
           updatedAt: pair.updatedAt,
+          teamId: pair.teamId,
         }),
     );
   }

--- a/backend/src/infra/db/repository/participant/participant-repository.integration.spec.ts
+++ b/backend/src/infra/db/repository/participant/participant-repository.integration.spec.ts
@@ -5,13 +5,37 @@ import { ParticipantDto } from '../../../../domain/repository-interface/particip
 describe('ParticipantRepository', () => {
   const participantRepository = new ParticipantRepository(prisma);
 
-  beforeEach(async () => {
-    await prisma.participant.deleteMany({});
+  afterEach(async () => {
+    // https://www.prisma.io/docs/concepts/components/prisma-client/crud#cascading-deletes-deleting-related-records
+    const deleteParticipants = prisma.participant.deleteMany({});
+    const deletePairs = prisma.pair.deleteMany({});
+    const deleteTeams = prisma.team.deleteMany({});
+
+    await prisma.$transaction([deleteParticipants, deletePairs, deleteTeams]);
   });
 
   describe('findAll', () => {
     it('正常系 全ての参加者を取得できること', async () => {
       // Arrange
+      await prisma.team.create({
+        data: {
+          id: '1',
+          name: '001',
+          createdAt: '2023-01-01T09:00:00Z',
+          updatedAt: '2023-01-01T09:00:00Z',
+        },
+      });
+
+      await prisma.pair.create({
+        data: {
+          id: '1',
+          name: '1',
+          createdAt: '2023-01-01T09:00:00Z',
+          updatedAt: '2023-01-01T09:00:00Z',
+          teamId: '1',
+        },
+      });
+
       await prisma.participant.createMany({
         data: [
           {
@@ -21,6 +45,7 @@ describe('ParticipantRepository', () => {
             status: 1,
             createdAt: '2023-01-01T09:00:00Z',
             updatedAt: '2023-01-01T09:00:00Z',
+            teamId: '1',
             pairId: '1',
           },
           {
@@ -30,6 +55,7 @@ describe('ParticipantRepository', () => {
             status: 2,
             createdAt: '2023-02-01T09:00:00Z',
             updatedAt: '2023-02-01T09:00:00Z',
+            teamId: '1',
             pairId: '1',
           },
         ],
@@ -47,6 +73,7 @@ describe('ParticipantRepository', () => {
           status: 1,
           createdAt: new Date('2023-01-01T09:00:00Z'),
           updatedAt: new Date('2023-01-01T09:00:00Z'),
+          teamId: '1',
           pairId: '1',
         }),
         new ParticipantDto({
@@ -56,6 +83,7 @@ describe('ParticipantRepository', () => {
           status: 2,
           createdAt: new Date('2023-02-01T09:00:00Z'),
           updatedAt: new Date('2023-02-01T09:00:00Z'),
+          teamId: '1',
           pairId: '1',
         }),
       ]);

--- a/backend/src/infra/db/repository/participant/participant-repository.ts
+++ b/backend/src/infra/db/repository/participant/participant-repository.ts
@@ -19,6 +19,7 @@ export class ParticipantRepository implements IParticipantRepository {
           status: participant.status,
           createdAt: participant.createdAt,
           updatedAt: participant.updatedAt,
+          teamId: participant.teamId,
           pairId: participant.pairId,
         }),
     );

--- a/backend/src/infra/db/repository/team/team-repository.integration.spec.ts
+++ b/backend/src/infra/db/repository/team/team-repository.integration.spec.ts
@@ -8,7 +8,7 @@ import { TeamDto } from '../../../../domain/repository-interface/team-repository
 describe('TeamRepository', () => {
   const teamRepository = new TeamRepository(prisma);
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await prisma.team.deleteMany({});
   });
 


### PR DESCRIPTION
📝 migrate失敗後に再度migrateしようとしたところ、全てのデータが消えるwarningが表示された。
```
$ yarn migrate:dev
yarn run v1.22.19
$ dotenv -e .development.env -- prisma migrate dev
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database "challenge", schema "public" at "localhost:5431"

The migration `20230223055612_team_pair_participant` failed.
✔ We need to reset the "public" schema at "localhost:5431"
Do you want to continue? All data will be lost. … yes

```